### PR TITLE
Get the Class name from the first namespace declaration in the model file

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -5,6 +5,7 @@ namespace BeyondCode\ErdGenerator;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
 use PhpParser\NodeVisitor\NameResolver;
@@ -42,10 +43,14 @@ class ModelFinder
         $code = file_get_contents($path);
 
         $statements = $parser->parse($code);
-
         $statements = $traverser->traverse($statements);
+        
+        // get the first namespace declaration in the file
+        $root_statement = collect($statements)->filter(function ($statement) {
+            return $statement instanceof Namespace_;
+        })->first();
 
-        return collect($statements[0]->stmts)
+        return collect($root_statement->stmts)
                 ->filter(function ($statement) {
                     return $statement instanceof Class_;
                 })


### PR DESCRIPTION
... instead of just using the first element in the statements array

When the model file contains a strict_types declaration above the namespace declaration, it will not be detected as a Model class, because the $statements array's first element is always checked for the class name which, in the case of a file with the strict types declaration in it, will always fail since the class name structure will be in the next element in the array