### PR TITLE
Recursively search for models with default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/beyondcode/laravel-er-diagram-generator.svg?style=flat-square)](https://scrutinizer-ci.com/g/beyondcode/laravel-er-diagram-generator)
 [![Total Downloads](https://img.shields.io/packagist/dt/beyondcode/laravel-er-diagram-generator.svg?style=flat-square)](https://packagist.org/packages/beyondcode/laravel-er-diagram-generator)
 
-This package lets you generate entity relation diagrams by inspecting the relationships defined in your model files. 
+This package lets you generate entity relation diagrams by inspecting the relationships defined in your model files.
 It is highly customizable.
 Behind the scenes, it uses [GraphViz](https://www.graphviz.org) to generate the graph.
 
@@ -37,13 +37,11 @@ If you are using Laravel 5.5+, the package will automatically register the servi
 
 ## Usage
 
-Once the package is installed, publish the configuration file using
+By default, the package will automatically detect all models in your `app` directory that extend the Eloquent Model class. If you would like you explicitly define where your models are located, you can publish the configuration file using the following command.
 
 ```bash
 php artisan vendor:publish --provider=BeyondCode\\ErdGenerator\\ErdGeneratorServiceProvider
 ```
-
-Open the configuration file and add all folders, that contain your model files.
 
 ## Generating Diagrams
 
@@ -51,15 +49,15 @@ You can generate entity relation diagrams using the provided artisan command:
 
 ```bash
 php artisan generate:erd
-``` 
+```
 
-This will generate a file called `graph.png`. 
+This will generate a file called `graph.png`.
 
 You can also specify a custom filename:
 
 ```bash
 php artisan generate:erd output.png
-``` 
+```
 
 Or use one of the other [output formats](https://www.graphviz.org/doc/info/output.html), like SVG:
 
@@ -71,7 +69,7 @@ php artisan generate:erd output.svg --format=svg
 
 Please take a look at the published `erd-generator.php` configuration file for all available customization options.
 
-## Examples 
+## Examples
 
 Here are some examples taken from the [Laravel.io](https://laravel.io) codebase.
 

--- a/config/config.php
+++ b/config/config.php
@@ -4,12 +4,18 @@ return [
 
     /*
      * All models in these directories will be scanned for ER diagram generation.
-     * The directories will not be scanned recursively, so be sure to add all
-     * directories that contain your models.
+     * By default, the `app` directory will be scanned recursively for models.
      */
     'directories' => [
-        // app_path('models'),
+        app_path(),
     ],
+
+    /*
+     * If true, all directories specified will be scanned recursively for models.
+     * Set this to false if you prefer to explicitly define each directory that should
+     * be scanned for models.
+     */
+    'recursive' => true,
 
     /*
      * The generator will automatically try to look up the model specific columns

--- a/src/GenerateDiagramCommand.php
+++ b/src/GenerateDiagramCommand.php
@@ -82,7 +82,9 @@ class GenerateDiagramCommand extends Command
     {
         $directories = config('erd-generator.directories');
 
-        $modelsFromDirectories = $this->getAllModelsFromEachDirectory($directories);
+        $modelsFromDirectories = empty($directories) ?
+            $this->modelFinder->getModelsInDirectory(app_path(), true) :
+            $this->getAllModelsFromEachDirectory($directories);
 
         return $modelsFromDirectories;
     }

--- a/src/GenerateDiagramCommand.php
+++ b/src/GenerateDiagramCommand.php
@@ -82,9 +82,7 @@ class GenerateDiagramCommand extends Command
     {
         $directories = config('erd-generator.directories');
 
-        $modelsFromDirectories = empty($directories) ?
-            $this->modelFinder->getModelsInDirectory(app_path(), true) :
-            $this->getAllModelsFromEachDirectory($directories);
+        $modelsFromDirectories = $this->getAllModelsFromEachDirectory($directories);
 
         return $modelsFromDirectories;
     }

--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -22,9 +22,13 @@ class ModelFinder
         $this->filesystem = $filesystem;
     }
 
-    public function getModelsInDirectory(string $directory): Collection
+    public function getModelsInDirectory(string $directory, bool $recursive = false): Collection
     {
-        return Collection::make($this->filesystem->files($directory))->map(function ($path) {
+        $files = $recursive ?
+            $this->filesystem->allFiles($directory) :
+            $this->filesystem->files($directory);
+
+        return Collection::make($files)->map(function ($path) {
             return $this->getFullyQualifiedClassNameFromFile($path);
         })->filter(function (string $className) {
             return !empty($className);
@@ -44,7 +48,7 @@ class ModelFinder
 
         $statements = $parser->parse($code);
         $statements = $traverser->traverse($statements);
-        
+
         // get the first namespace declaration in the file
         $root_statement = collect($statements)->filter(function ($statement) {
             return $statement instanceof Namespace_;
@@ -59,5 +63,5 @@ class ModelFinder
                 })
                 ->first() ?? '';
     }
-    
+
 }

--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -22,9 +22,9 @@ class ModelFinder
         $this->filesystem = $filesystem;
     }
 
-    public function getModelsInDirectory(string $directory, bool $recursive = false): Collection
+    public function getModelsInDirectory(string $directory): Collection
     {
-        $files = $recursive ?
+        $files = config('erd-generator.recursive') ?
             $this->filesystem->allFiles($directory) :
             $this->filesystem->files($directory);
 


### PR DESCRIPTION
This change allows the user to not have to publish the config file to their project if they don't want to.

If the config is not published, then the empty directories array indicates that all models in the `app` directory should recursively be scanned and generated.

This is slightly related to #12 though doesn't solve it directly, though I suspect that many people want all of their models.