### PR TITLE
Generate default filename from format string

### DIFF
--- a/src/GenerateDiagramCommand.php
+++ b/src/GenerateDiagramCommand.php
@@ -12,12 +12,14 @@ class GenerateDiagramCommand extends Command
 {
     const FORMAT_TEXT = 'text';
 
+    const DEFAULT_FILENAME = 'graph';
+
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $signature = 'generate:erd {filename=graph.png} {--format=png}';
+    protected $signature = 'generate:erd {filename?} {--format=png}';
 
     /**
      * The console command description.
@@ -72,10 +74,16 @@ class GenerateDiagramCommand extends Command
             return;
         }
 
-        $graph->export($this->option('format'), $this->argument('filename'));
+        $graph->export($this->option('format'), $this->getOutputFileName());
 
         $this->info(PHP_EOL);
-        $this->info('Wrote diagram to '.$this->argument('filename'));
+        $this->info('Wrote diagram to ' . $this->getOutputFileName());
+    }
+
+    protected function getOutputFileName(): string
+    {
+        return $this->argument('filename') ?:
+            static::DEFAULT_FILENAME . '.' . $this->option('format');
     }
 
     protected function getModelsThatShouldBeInspected(): Collection


### PR DESCRIPTION
This uses the format string to generate the default filename (if no filename is supplied). Currently if you change the format you have to explicitly set the filename, or you end up with a `.png` extension on a JPEG file for example.

Using the format string isn't correct 100% of the time, but works for most common formats and I don't think it will produce any more problems than leaving the extension as `.png`.