### PR TITLE
Classes without namespace break the ModelFinder

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -57,6 +57,10 @@ class ModelFinder
             return $statement instanceof Namespace_;
         })->first();
 
+        if (! $root_statement) {
+            return '';
+        }
+
         return collect($root_statement->stmts)
                 ->filter(function ($statement) {
                     return $statement instanceof Class_;
@@ -66,5 +70,4 @@ class ModelFinder
                 })
                 ->first() ?? '';
     }
-
 }

--- a/tests/Models/SomeClassWithoutNamespace.php
+++ b/tests/Models/SomeClassWithoutNamespace.php
@@ -1,0 +1,6 @@
+<?php
+
+class SomeClassWithoutNamespace
+{
+
+}


### PR DESCRIPTION
Check if there is a namespace before going further.

Fix #27 