### PR TITLE
Laravel 6 Support: Removed deprecated global helper array and str

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\ErdGenerator;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class Model
 {
@@ -30,7 +31,7 @@ class Model
      */
     public function getNodeName()
     {
-        return str_replace('-', '', str_slug($this->model));
+        return str_replace('-', '', Str::slug($this->model));
     }
 
     /**

--- a/src/ModelRelation.php
+++ b/src/ModelRelation.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace BeyondCode\ErdGenerator;
+use Illuminate\Support\Str;
 
 class ModelRelation
 {
@@ -32,7 +33,7 @@ class ModelRelation
      */
     public function getModelNodeName()
     {
-        return str_slug($this->model);
+        return Str::slug($this->model);
     }
 
     /**

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
+use Illuminate\Support\Arr;
+
 
 class RelationFinder
 {
@@ -40,7 +42,7 @@ class RelationFinder
 
         $relations = $relations->filter();
 
-        if ($ignoreRelations = array_get(config('erd-generator.ignore', []),$model))
+        if ($ignoreRelations = Arr::get(config('erd-generator.ignore', []),$model))
         {
             $relations = $relations->diffKeys(array_flip($ignoreRelations));
         }
@@ -96,5 +98,5 @@ class RelationFinder
         } catch (\Throwable $e) {}
         return null;
     }
-    
+
 }

--- a/tests/GetModelRelationsTest.php
+++ b/tests/GetModelRelationsTest.php
@@ -8,6 +8,8 @@ use BeyondCode\ErdGenerator\Tests\Models\Avatar;
 use BeyondCode\ErdGenerator\Tests\Models\Comment;
 use BeyondCode\ErdGenerator\Tests\Models\Post;
 use BeyondCode\ErdGenerator\Tests\Models\User;
+use Illuminate\Support\Arr;
+
 
 class GetModelRelationsTest extends TestCase
 {
@@ -63,7 +65,7 @@ class GetModelRelationsTest extends TestCase
         $relations = $finder->getModelRelations(User::class);
 
         $this->assertCount(2, $relations);
-        $this->assertNull(array_get($relations, 'posts'));
+        $this->assertNull(Arr::get($relations, 'posts'));
     }
 
 }


### PR DESCRIPTION
Removed deprecated global helper array (array_get) and str (str_slug)
Replaced with \Illuminate\Support classes