### PR TITLE
Fix the broken tests for older laravel versions

### DIFF
--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -40,7 +40,7 @@ class ModelFinder
             return !empty($className)
                 && is_subclass_of($className, EloquentModel::class)
                 && ! (new ReflectionClass($className))->isAbstract();
-        })->diff($ignoreModels);
+        })->diff($ignoreModels)->sort();
     }
 
     protected function getFullyQualifiedClassNameFromFile(string $path): string

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -80,7 +80,7 @@ class RelationFinder
 
                 if ($return instanceof BelongsTo) {
                     $foreignKey = $this->getParentKey($return->getQualifiedOwnerKeyName());
-                    $localKey = $return->getForeignKeyName();
+                    $localKey = method_exists($return, 'getForeignKeyName') ? $return->getForeignKeyName() : $return->getForeignKey();
                 }
 
                 return [


### PR DESCRIPTION
This PR adds backwards compatibility for the belongsTo relationships for Laravel versions < 5.8. The `getForeignKey` method has been renamed to `getForeignKeyName` in Laravel 5.8.