### PR TITLE
Allow white-listing models

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -23,7 +23,18 @@ return [
         //     'user'
         // ]
     ],
-    
+
+    /*
+     * If you want to see only specific models, specify them here using fully qualified
+     * classnames.
+     *
+     * Note: that if this array is filled, the 'ignore' array will not be used.
+    */
+    'whitelist' => [
+        // App\User::class,
+        // App\Post::class,
+    ],
+
     /*
      * If true, all directories specified will be scanned recursively for models.
      * Set this to false if you prefer to explicitly define each directory that should

--- a/tests/FindModelsFromConfigTest.php
+++ b/tests/FindModelsFromConfigTest.php
@@ -46,4 +46,22 @@ class FindModelsFromConfigTest extends TestCase
             $classNames->values()->all()
         );
     }
+
+    /** @test */
+    public function it_will_only_return_models_in_whitelist_if_present()
+    {
+        $this->app['config']->set('erd-generator.whitelist', [
+            Avatar::class,
+        ]);
+
+        $finder = new ModelFinder(app()->make('files'));
+
+        $classNames = $finder->getModelsInDirectory(__DIR__ . "/Models");
+
+        $this->assertCount(1, $classNames);
+        $this->assertEquals(
+            [Avatar::class],
+            $classNames->values()->all()
+        );
+    }
 }


### PR DESCRIPTION
This commit allows showing only white-listed models, ignoring the `ignore` array.