### PR TITLE
bugfix: use OS directory seperator

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,7 +7,7 @@ return [
      * By default, the `app` directory will be scanned recursively for models.
      */
     'directories' => [
-        base_path('app\Models'),
+        base_path('app' . DIRECTORY_SEPARATOR . 'Models'),
     ],
 
     /*


### PR DESCRIPTION
- backslash is windows only
- other use forward slash, e.g. Linux based system and those would fail
  with default config