### PR TITLE
basepath using slash

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,7 +7,7 @@ return [
      * By default, the `app` directory will be scanned recursively for models.
      */
     'directories' => [
-        base_path('app\Models'),
+        base_path('app/Models'),
     ],
 
     /*


### PR DESCRIPTION
base_path() helper function is receiving slash in official documentations.

https://laravel.com/docs/5.5/helpers#method-base-path

It will throw error with backslash path.