### PR TITLE
Added Laravel 9, Linux Filesystem and Php 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Laravel ER Diagram Generator
+# Laravel ER Diagram Generator for Php 8, Laravel 9 and Linux Filesystem support
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/beyondcode/laravel-er-diagram-generator.svg?style=flat-square)](https://packagist.org/packages/beyondcode/laravel-er-diagram-generator)
 [![Build Status](https://img.shields.io/travis/beyondcode/laravel-er-diagram-generator/master.svg?style=flat-square)](https://travis-ci.org/beyondcode/laravel-er-diagram-generator)

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "doctrine/dbal": "~2.3",
+        "php": "^7.3|^8.0",
+        "doctrine/dbal": "^3.3",
         "phpdocumentor/graphviz": "^1.0",
-        "nikic/php-parser":"^2.0|^3.0|^4.0"
+        "nikic/php-parser": "^4.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
-        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8|^4.0",
-        "phpunit/phpunit": "^7.0| ^8.0",
-        "spatie/phpunit-snapshot-assertions": "^1.3"
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^8.3|^9.0",
+        "spatie/phpunit-snapshot-assertions": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/config.php
+++ b/config/config.php
@@ -7,7 +7,7 @@ return [
      * By default, the `app` directory will be scanned recursively for models.
      */
     'directories' => [
-        base_path('app\Models'),
+        base_path('app' . DIRECTORY_SEPARATOR . 'Models'),
     ],
 
     /*


### PR DESCRIPTION
I have tested it on a project with laravel 9, php 8 and using MacOS and its working good.

If you want to try it put in your composer.json:

```
    "repositories": {
        "beyondcode/laravel-er-diagram-generator":{
            "type": "github",
            "url": "https://github.com/robertmunoz1999/laravel-er-diagram-generator"
        },
    },
    "require": {
        "beyondcode/laravel-er-diagram-generator": "dev-master"
    },
```

then run composer update