### PR TITLE
FIx PHP 8.2 deprecations with string interpolation

### DIFF
--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -22,7 +22,7 @@ class GraphBuilder
         $this->graph = new Graph();
 
         foreach (config('erd-generator.graph') as $key => $value) {
-            $this->graph->{"set${key}"}($value);
+            $this->graph->{"set{$key}"}($value);
         }
 
         $this->addModelsToGraph($models);
@@ -94,7 +94,7 @@ class GraphBuilder
         $node->setLabel($this->getModelLabel($eloquentModel, $label));
 
         foreach (config('erd-generator.node') as $key => $value) {
-            $node->{"set${key}"}($value);
+            $node->{"set{$key}"}($value);
         }
 
         $this->graph->setNode($node);
@@ -129,11 +129,11 @@ class GraphBuilder
         $edge->setXLabel($relation->getType() . PHP_EOL . $relation->getName());
 
         foreach (config('erd-generator.edge') as $key => $value) {
-            $edge->{"set${key}"}($value);
+            $edge->{"set{$key}"}($value);
         }
 
         foreach (config('erd-generator.relations.' . $relation->getType(), []) as $key => $value) {
-            $edge->{"set${key}"}($value);
+            $edge->{"set{$key}"}($value);
         }
 
         $this->graph->link($edge);


### PR DESCRIPTION
Running on PHP8.2 throws deprecated warnings. `${var}` got deprecated in 8.2 and will be removed later.

This PR replaces them with `{$var}`.

More info: https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated