### PR TITLE
Allow php-parser 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.1|^8.0",
         "doctrine/dbal": "~2.3|^3.3",
         "phpdocumentor/graphviz": "^1.0",
-        "nikic/php-parser": "^2.0|^3.0|^4.0"
+        "nikic/php-parser": "^2.0|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/src/ModelFinder.php
+++ b/src/ModelFinder.php
@@ -54,7 +54,10 @@ class ModelFinder
 
     protected function getFullyQualifiedClassNameFromFile(string $path): string
     {
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $factory = new ParserFactory();
+        $parser = method_exists($factory, 'createForHostVersion')
+            ? $factory->createForHostVersion()
+            : $factory->create(ParserFactory::PREFER_PHP7);
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NameResolver());


### PR DESCRIPTION
5.0 had some breaking changes, but it improves pretty printing and lots of packages in the php ecosystem already support it:

```
phpunit/php-code-coverage 10.1.11 requires nikic/php-parser (^4.18 || ^5.0) 
psy/psysh                 v0.12.0 requires nikic/php-parser (^5.0 || ^4.0)  
sebastian/complexity      3.2.0   requires nikic/php-parser (^4.18 || ^5.0) 
sebastian/lines-of-code   2.0.2   requires nikic/php-parser (^4.18 || ^5.0) 
```

This pr changes the requirements to also allow 5.x versions, while preserving backwards compatibility for lower versions.
On 5.x the new `ParserFactory::createForHostVersion()` is used to create a parser matching the current PHP version. Older versions use the same code as before using `ParserFactory::PREFER_PHP_7`.

I tested it using a fresh Laravel installation with `nikic/php-parser` 4.x and 5.x respectively and both succeeded without any issues.