### PR TITLE
Allow doctrine/dbal 4 upwards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "doctrine/dbal": "~2.3|^3.3",
+        "doctrine/dbal": "~2.3|^3.3|^4.0",
         "phpdocumentor/graphviz": "^1.0",
         "nikic/php-parser": "^2.0|^3.0|^4.0|^5.0"
     },


### PR DESCRIPTION
wThis PR allows `doctrine/dbal:^4.0` as dependency, which makes it installable and executable with PHP 8.3 and Laravel 11.

Fixes #112 

Nevertheless, I still have a red test suite:
```
composer test
> vendor/bin/phpunit
PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.10
Configuration: /Users/bambamboole/Projects/forks/laravel-er-diagram-generator/phpunit.xml.dist
Warning:       No code coverage driver available

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 17:
  - Element 'filter': This element is not expected.

  Test results may not be as expected.


...I
In ConnectsToDatabase.php line 22:
                                                                                                                                                                                                   
  Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL  
  \Driver::connect(array $params): Doctrine\DBAL\Driver\Connection                                                                                                                                 
                                                                                                                                                                                                   


In ConnectsToDatabase.php line 22:
                                                                                                                                                                                                   
  Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL  
  \Driver::connect(array $params): Doctrine\DBAL\Driver\Connection                                                                                                                                 
                                                                                                                                                                                                   


In ConnectsToDatabase.php line 22:
                                                                                                                                                                                                   
  Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL  
  \Driver::connect(array $params): Doctrine\DBAL\Driver\Connection                                                                                                                                 
                                                                                                                                                                                                   


In ConnectsToDatabase.php line 22:
                                                                                                                                                                                                   
  Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL  
  \Driver::connect(array $params): Doctrine\DBAL\Driver\Connection                                                                                                                                 
                                                                                                                                                                                                   


In ConnectsToDatabase.php line 22:
                                                                                                                                                                                                   
  Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL  
  \Driver::connect(array $params): Doctrine\DBAL\Driver\Connection                                                                                                                                 
                                                                                                                                                                                                   


Fatal error: Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL\Driver::connect(array $params): Doctrine\DBAL\Driver\Connection in /Users/bambamboole/Projects/forks/laravel-er-diagram-generator/vendor/laravel/framework/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php on line 22
Script vendor/bin/phpunit handling the test event returned with error code 255
```