### PR TITLE
Enable support for laravel 11.x and php 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "doctrine/dbal": "~2.3|^3.3",
+        "doctrine/dbal": "~2.3|^3.3|^4.0",
         "phpdocumentor/graphviz": "^1.0",
         "nikic/php-parser": "^2.0|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
         "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8|^4.0|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^7.0| ^8.0|^9.5.10",
-        "spatie/phpunit-snapshot-assertions": "^1.3|^4.2"
+        "phpunit/phpunit": "^7.0| ^8.0|^9.5.10|^10.5|^11.0.1",
+        "spatie/phpunit-snapshot-assertions": "^1.3|^4.2|^5.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is intended to fix #112 and inspired by #103. It accomplishes this by updating `composer.json` to allow for the latest versions of `doctrine/dbal`, `phpunit/phpunit`, and `spatie/phpunit-snapshot-assertions`.

Passes tests and verified in project to work