### PR TITLE
Use an alternate method of reading column details if the old way fails

### DIFF
--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\ErdGenerator;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Schema;
 use phpDocumentor\GraphViz\Graph;
 use Illuminate\Support\Collection;
 use phpDocumentor\GraphViz\Node;
@@ -49,6 +50,11 @@ class GraphBuilder
         } catch (\Throwable $e) {
         }
 
+        try {
+            return Schema::getColumns($model->getTable());
+        } catch (\Throwable $e) {
+        }
+
         return [];
     }
 
@@ -61,11 +67,18 @@ class GraphBuilder
         if (config('erd-generator.use_db_schema')) {
             $columns = $this->getTableColumnsFromModel($model);
             foreach ($columns as $column) {
-                $label = $column->getName();
-                if (config('erd-generator.use_column_types')) {
-                    $label .= ' ('.$column->getType()->getName().')';
+                if (is_object($column)) {
+                    $name = $column->getName();
+                    $typeName = $column->getType()->getName();
+                } else { // it's an array!
+                    $name = $column['name'];
+                    $typeName = $column['type_name'];
                 }
-                $table .= '<tr width="100%"><td port="' . $column->getName() . '" align="left" width="100%"  bgcolor="'.config('erd-generator.table.row_background_color').'"><font color="'.config('erd-generator.table.row_font_color').'" >' . $label . '</font></td></tr>' . PHP_EOL;
+                $label = $name;
+                if (config('erd-generator.use_column_types')) {
+                    $label .= ' ('. $typeName .')';
+                }
+                $table .= '<tr width="100%"><td port="' . $name . '" align="left" width="100%"  bgcolor="'.config('erd-generator.table.row_background_color').'"><font color="'.config('erd-generator.table.row_font_color').'" >' . $label . '</font></td></tr>' . PHP_EOL;
             }
         }
 

--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -71,8 +71,8 @@ class GraphBuilder
                     $name = $column->getName();
                     $typeName = $column->getType()->getName();
                 } else { // it's an array!
-                    $name = $column['name'];
-                    $typeName = $column['type_name'];
+                    $name = $column['name'] ?? '';
+                    $typeName = $column['type_name'] ?? '';
                 }
                 $label = $name;
                 if (config('erd-generator.use_column_types')) {


### PR DESCRIPTION
I basically used the solution from https://github.com/beyondcode/laravel-er-diagram-generator/issues/70#issuecomment-2569208746.

Because the two techniques return different results, I had to put a shim in between reading and output for the column names.

But, it now shows column names in laravel 11 projects.

Fixes #70 