### PR TITLE
Add structured text output for AI model context

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,39 @@ This will generate a text file with the GraphViz DOT representation of the ER di
 
 ### Structured Text Output for AI Models
 
-If you want to generate a structured text representation of the ER diagram that is more suitable for AI models, you can use the `--structured` option:
+If you want to generate a structured text representation of the ER diagram that is more suitable for AI models, simply specify a filename with a `.txt` extension:
 
 ```bash
-php artisan generate:erd output.txt --structured
+php artisan generate:erd output.txt
 ```
 
-This will generate a Markdown file with a structured representation of the entities and their relationships, which can be used as context for AI models.
+This will automatically generate a Markdown file with a structured representation of the entities and their relationships, which can be used as context for AI models.
+
+#### Output Format
+
+The structured output format looks like this:
+
+```markdown
+# Entity Relationship Diagram
+
+## Entities
+
+### User (`App\Models\User`)
+
+#### Attributes:
+- `id` (integer)
+- `name` (string)
+- `email` (string)
+...
+
+## Relationships
+
+### User Relationships
+- **HasMany** `posts` to Post (Local Key: `id`, Foreign Key: `user_id`)
+...
+```
+
+This format is particularly useful when providing context to AI models about your database structure.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ Or use one of the other [output formats](https://www.graphviz.org/doc/info/outpu
 php artisan generate:erd output.svg --format=svg
 ```
 
+### Text Output
+
+If you want to generate a text representation of the ER diagram instead of an image, you can use the `--text-output` option:
+
+```bash
+php artisan generate:erd output.txt --text-output
+```
+
+This will generate a text file with the GraphViz DOT representation of the ER diagram.
+
+### Structured Text Output for AI Models
+
+If you want to generate a structured text representation of the ER diagram that is more suitable for AI models, you can use the `--structured` option:
+
+```bash
+php artisan generate:erd output.txt --structured
+```
+
+This will generate a Markdown file with a structured representation of the entities and their relationships, which can be used as context for AI models.
+
 ## Customization
 
 Please take a look at the published `erd-generator.php` configuration file for all available customization options.

--- a/src/GenerateDiagramCommand.php
+++ b/src/GenerateDiagramCommand.php
@@ -70,19 +70,9 @@ class GenerateDiagramCommand extends Command
             );
         });
 
-        // Check if output filename has .txt extension
-        $outputFileName = $this->getOutputFileName();
-        if (pathinfo($outputFileName, PATHINFO_EXTENSION) === 'txt') {
-            // Generate structured text output for .txt files
-            $textOutput = $this->graphBuilder->generateStructuredTextRepresentation($models);
-            file_put_contents($outputFileName, $textOutput);
-            $this->info(PHP_EOL);
-            $this->info('Wrote structured ER diagram to ' . $outputFileName);
-            return;
-        }
-
         $graph = $this->graphBuilder->buildGraph($models);
 
+        // First check for text-output option
         if ($this->option('text-output') || $this->option('format') === self::FORMAT_TEXT) {
             $textOutput = $graph->__toString();
             
@@ -97,6 +87,17 @@ class GenerateDiagramCommand extends Command
             
             // Otherwise just output to console
             $this->info($textOutput);
+            return;
+        }
+
+        // Then check for .txt extension in filename
+        $outputFileName = $this->getOutputFileName();
+        if (pathinfo($outputFileName, PATHINFO_EXTENSION) === 'txt') {
+            // Generate structured text output for .txt files
+            $textOutput = $this->graphBuilder->generateStructuredTextRepresentation($models);
+            file_put_contents($outputFileName, $textOutput);
+            $this->info(PHP_EOL);
+            $this->info('Wrote structured ER diagram to ' . $outputFileName);
             return;
         }
 

--- a/src/GenerateDiagramCommand.php
+++ b/src/GenerateDiagramCommand.php
@@ -19,7 +19,7 @@ class GenerateDiagramCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'generate:erd {filename?} {--format=png} {--text-output : Output as text file instead of image} {--structured : Generate structured text output for AI models}';
+    protected $signature = 'generate:erd {filename?} {--format=png} {--text-output : Output as text file instead of image}';
 
     /**
      * The console command description.
@@ -70,13 +70,14 @@ class GenerateDiagramCommand extends Command
             );
         });
 
-        // If structured text output is requested, generate it
-        if ($this->option('structured')) {
+        // Check if output filename has .txt extension
+        $outputFileName = $this->getOutputFileName();
+        if (pathinfo($outputFileName, PATHINFO_EXTENSION) === 'txt') {
+            // Generate structured text output for .txt files
             $textOutput = $this->graphBuilder->generateStructuredTextRepresentation($models);
-            $outputFileName = $this->getTextOutputFileName();
             file_put_contents($outputFileName, $textOutput);
             $this->info(PHP_EOL);
-            $this->info('Wrote structured text diagram to ' . $outputFileName);
+            $this->info('Wrote structured ER diagram to ' . $outputFileName);
             return;
         }
 
@@ -99,10 +100,10 @@ class GenerateDiagramCommand extends Command
             return;
         }
 
-        $graph->export($this->option('format'), $this->getOutputFileName());
+        $graph->export($this->option('format'), $outputFileName);
 
         $this->info(PHP_EOL);
-        $this->info('Wrote diagram to ' . $this->getOutputFileName());
+        $this->info('Wrote diagram to ' . $outputFileName);
     }
 
     protected function getOutputFileName(): string

--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -72,8 +72,10 @@ class GraphBuilder
                 
                 foreach ($model->getRelations() as $relation) {
                     /** @var ModelRelation $relation */
-                    $relatedModel = $models->first(function ($m) use ($relation) {
-                        return $m->getModel() === $relation->getRelatedModel();
+                    // Find the related model by comparing model class names
+                    $relatedModelClass = $relation->getModel();
+                    $relatedModel = $models->first(function ($m) use ($relatedModelClass) {
+                        return $m->getModel() === $relatedModelClass;
                     });
                     
                     if ($relatedModel) {

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -58,4 +58,89 @@ class GenerationTest extends TestCase
 
         $this->assertStringContainsString('Wrote diagram to graph.jpeg', Artisan::output());
     }
+
+    /** @test */
+    public function it_generates_text_output_file()
+    {
+        $this->app['config']->set('erd-generator.directories', [__DIR__ . '/Models']);
+        
+        $outputFile = __DIR__ . '/output_test.txt';
+        
+        // Make sure the file doesn't exist before the test
+        if (file_exists($outputFile)) {
+            unlink($outputFile);
+        }
+        
+        Artisan::call('generate:erd', [
+            'filename' => $outputFile,
+            '--text-output' => true
+        ]);
+        
+        $this->assertFileExists($outputFile);
+        $this->assertStringContainsString('Wrote text diagram to ' . $outputFile, Artisan::output());
+        
+        // Check if the file contains GraphViz DOT content
+        $fileContent = file_get_contents($outputFile);
+        $this->assertStringContainsString('digraph', $fileContent);
+        
+        // Clean up
+        if (file_exists($outputFile)) {
+            unlink($outputFile);
+        }
+    }
+    
+    /** @test */
+    public function it_generates_structured_text_output_file()
+    {
+        $this->app['config']->set('erd-generator.directories', [__DIR__ . '/Models']);
+        
+        $outputFile = __DIR__ . '/structured_test.txt';
+        
+        // Make sure the file doesn't exist before the test
+        if (file_exists($outputFile)) {
+            unlink($outputFile);
+        }
+        
+        Artisan::call('generate:erd', [
+            'filename' => $outputFile,
+            '--structured' => true
+        ]);
+        
+        $this->assertFileExists($outputFile);
+        $this->assertStringContainsString('Wrote structured text diagram to ' . $outputFile, Artisan::output());
+        
+        // Check if the file contains structured Markdown content
+        $fileContent = file_get_contents($outputFile);
+        $this->assertStringContainsString('# Entity Relationship Diagram', $fileContent);
+        $this->assertStringContainsString('## Entities', $fileContent);
+        $this->assertStringContainsString('## Relationships', $fileContent);
+        
+        // Clean up
+        if (file_exists($outputFile)) {
+            unlink($outputFile);
+        }
+    }
+    
+    /** @test */
+    public function it_generates_structured_text_output_with_correct_content()
+    {
+        $this->app['config']->set('erd-generator.directories', [__DIR__ . '/Models']);
+        
+        // Get the structured text output directly from the GraphBuilder
+        $models = $this->app->make('BeyondCode\ErdGenerator\ModelFinder')
+            ->getModelsInDirectory(__DIR__ . '/Models')
+            ->transform(function ($model) {
+                return new \BeyondCode\ErdGenerator\Model(
+                    $model,
+                    (new \ReflectionClass($model))->getShortName(),
+                    $this->app->make('BeyondCode\ErdGenerator\RelationFinder')->getModelRelations($model)
+                );
+            });
+        
+        $structuredOutput = $this->app->make('BeyondCode\ErdGenerator\GraphBuilder')
+            ->generateStructuredTextRepresentation($models);
+        
+        // Assert the structured output matches the snapshot
+        $this->assertMatchesSnapshot($structuredOutput);
+    }
 }

--- a/tests/GenerationTest.php
+++ b/tests/GenerationTest.php
@@ -60,7 +60,7 @@ class GenerationTest extends TestCase
     }
 
     /** @test */
-    public function it_generates_text_output_file()
+    public function it_generates_text_output_file_with_text_output_option()
     {
         $this->app['config']->set('erd-generator.directories', [__DIR__ . '/Models']);
         
@@ -90,7 +90,7 @@ class GenerationTest extends TestCase
     }
     
     /** @test */
-    public function it_generates_structured_text_output_file()
+    public function it_generates_structured_text_output_for_txt_extension()
     {
         $this->app['config']->set('erd-generator.directories', [__DIR__ . '/Models']);
         
@@ -102,12 +102,11 @@ class GenerationTest extends TestCase
         }
         
         Artisan::call('generate:erd', [
-            'filename' => $outputFile,
-            '--structured' => true
+            'filename' => $outputFile
         ]);
         
         $this->assertFileExists($outputFile);
-        $this->assertStringContainsString('Wrote structured text diagram to ' . $outputFile, Artisan::output());
+        $this->assertStringContainsString('Wrote structured ER diagram to ' . $outputFile, Artisan::output());
         
         // Check if the file contains structured Markdown content
         $fileContent = file_get_contents($outputFile);


### PR DESCRIPTION
# Add structured text output for AI model context

## Description
This PR adds automatic structured text output for AI models when using a `.txt` file extension:

When a filename with a `.txt` extension is provided, the package automatically generates a structured Markdown representation of the ER diagram that is specifically formatted to be used as context for AI models.

## Why
When working with AI models like ChatGPT or Claude, providing structured context about database relationships can significantly improve the quality of generated code. This feature allows developers to easily generate documentation about their database structure that can be fed directly to AI assistants.

## Changes
- Added automatic detection of `.txt` file extension to generate structured output
- Added `generateStructuredTextRepresentation` method to `GraphBuilder` class
- Updated README with documentation for the new functionality
- Added tests for the new functionality

## Example Output
The structured output format looks like this:

```markdown
# Entity Relationship Diagram

## Entities

### User (`App\Models\User`)

#### Attributes:
- `id` (integer)
- `name` (string)
- `email` (string)
...

## Relationships

### User Relationships
- **HasMany** `posts` to Post (Local Key: `id`, Foreign Key: `user_id`)
...
```
```
