### PR TITLE
Use laravel getColumns for getting columns names and types. Add ignore_columns option

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -57,6 +57,16 @@ return [
     'use_column_types' => true,
 
     /*
+     * If you want to ignore specific columns in specific tables you can specify them here.
+     * Use the dot notation to specify the table and the column : table.column
+     * This option only apply when 'use_db_schema' is set to true.
+    */
+    'ignore_columns' => [
+        // 'users.lastname',
+        // 'posts.description',
+    ],
+
+    /*
      * These colors will be used in the table representation for each entity in
      * your graph.
      */

--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -39,7 +39,10 @@ class GraphBuilder
             $columns = Schema::getColumns($table);
             if (config('erd-generator.ignore_columns')) {
                 $columns = collect($columns)->filter(function($column) use($table) {
-                    return !in_array($table.'.'.$column['name'],config('erd-generator.ignore_columns'));
+                    if (isset($column['name'])){
+                        return !in_array($table.'.'.$column['name'],config('erd-generator.ignore_columns'));
+                    }
+                    return false;
                 });
             }
 
@@ -60,11 +63,14 @@ class GraphBuilder
         if (config('erd-generator.use_db_schema')) {
             $columns = $this->getTableColumnsFromModel($model);
             foreach ($columns as $column) {
+
                 $label = $column['name'];
-                if (config('erd-generator.use_column_types')) {
+                if (config('erd-generator.use_column_types') && isset($column['type'])) {
                     $label .= ' ('.$column['type'].')';
                 }
                 $table .= '<tr width="100%"><td port="' . $column['name'] . '" align="left" width="100%"  bgcolor="'.config('erd-generator.table.row_background_color').'"><font color="'.config('erd-generator.table.row_font_color').'" >' . $label . '</font></td></tr>' . PHP_EOL;
+
+
             }
         }
 

--- a/src/GraphBuilder.php
+++ b/src/GraphBuilder.php
@@ -7,6 +7,7 @@ use phpDocumentor\GraphViz\Graph;
 use Illuminate\Support\Collection;
 use phpDocumentor\GraphViz\Node;
 use \Illuminate\Database\Eloquent\Model as EloquentModel;
+use Illuminate\Support\Facades\Schema;
 
 class GraphBuilder
 {
@@ -34,18 +35,16 @@ class GraphBuilder
     {
         try {
 
-            $table = $model->getConnection()->getTablePrefix() . $model->getTable();
-            $schema = $model->getConnection()->getDoctrineSchemaManager($table);
-            $databasePlatform = $schema->getDatabasePlatform();
-            $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
-
-            $database = null;
-
-            if (strpos($table, '.')) {
-                list($database, $table) = explode('.', $table);
+            $table = $model->getTable();
+            $columns = Schema::getColumns($table);
+            if (config('erd-generator.ignore_columns')) {
+                $columns = collect($columns)->filter(function($column) use($table) {
+                    return !in_array($table.'.'.$column['name'],config('erd-generator.ignore_columns'));
+                });
             }
 
-            return $schema->listTableColumns($table, $database);
+            return $columns;
+
         } catch (\Throwable $e) {
         }
 
@@ -61,11 +60,11 @@ class GraphBuilder
         if (config('erd-generator.use_db_schema')) {
             $columns = $this->getTableColumnsFromModel($model);
             foreach ($columns as $column) {
-                $label = $column->getName();
+                $label = $column['name'];
                 if (config('erd-generator.use_column_types')) {
-                    $label .= ' ('.$column->getType()->getName().')';
+                    $label .= ' ('.$column['type'].')';
                 }
-                $table .= '<tr width="100%"><td port="' . $column->getName() . '" align="left" width="100%"  bgcolor="'.config('erd-generator.table.row_background_color').'"><font color="'.config('erd-generator.table.row_font_color').'" >' . $label . '</font></td></tr>' . PHP_EOL;
+                $table .= '<tr width="100%"><td port="' . $column['name'] . '" align="left" width="100%"  bgcolor="'.config('erd-generator.table.row_background_color').'"><font color="'.config('erd-generator.table.row_font_color').'" >' . $label . '</font></td></tr>' . PHP_EOL;
             }
         }
 


### PR DESCRIPTION
The GraphBuilder getTableColumnsFromModel method was not working anymore.
I modified it to use the Laravel way of getting columns instead of the deprecated Doctrine one.

I also added a new option to ignore specific columns