### PR TITLE
Chore: Add debug logging for silent exception in `RelationFinder.php`

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -11,6 +11,13 @@ return [
     ],
 
     /*
+     * If you want to enable debug logging when a model method cannot be
+     * analyzed during relation discovery, set this to true.
+     * Useful for troubleshooting unexpected ERD generation issues.
+     */
+    // 'debug_relations' => true,
+
+    /*
      * If you want to ignore complete models or certain relations of a specific model,
      * you can specify them here.
      * To ignore a model completely, just add the fully qualified classname.

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 
 
 class RelationFinder
@@ -95,7 +96,9 @@ class RelationFinder
                     )
                 ];
             }
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) {
+            Log::debug("Could not analyze method {$method->getName()} on {$model}: {$e->getMessage()}");
+        }
         return null;
     }
 

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -31,7 +31,7 @@ class RelationFinder
         $methods = Collection::make($class->getMethods(ReflectionMethod::IS_PUBLIC))
             ->merge($traitMethods)
             ->reject(function (ReflectionMethod $method) use ($model) {
-                return $method->class !== $model || $method->getNumberOfParameters() > 0 || $method->isStatic();;
+                return $method->class !== $model || $method->getNumberOfParameters() > 0 || $method->isStatic();
             });
 
         $relations = Collection::make();

--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 
 
 class RelationFinder
@@ -95,7 +96,13 @@ class RelationFinder
                     )
                 ];
             }
-        } catch (\Throwable $e) {}
+        } catch (\Throwable $e) {
+            // Non-relation methods may throw when invoked; this is expected.
+            // To enable debug logging, set 'debug_relations' => true in config/erd-generator.php
+            if (config('erd-generator.debug_relations', false)) {
+                Log::debug("Could not analyze method {$method->getName()} on {$model}: {$e->getMessage()}");
+            }
+        }
         return null;
     }
 

--- a/tests/GetModelRelationsTest.php
+++ b/tests/GetModelRelationsTest.php
@@ -7,14 +7,14 @@ use BeyondCode\ErdGenerator\RelationFinder;
 use BeyondCode\ErdGenerator\Tests\Models\Avatar;
 use BeyondCode\ErdGenerator\Tests\Models\Comment;
 use BeyondCode\ErdGenerator\Tests\Models\Post;
+use BeyondCode\ErdGenerator\Tests\Fixtures\ModelWithThrowingMethod;
 use BeyondCode\ErdGenerator\Tests\Models\User;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\Test;
-
 
 class GetModelRelationsTest extends TestCase
 {
-
     #[Test]
     public function it_can_find_model_relations()
     {
@@ -67,6 +67,26 @@ class GetModelRelationsTest extends TestCase
 
         $this->assertCount(2, $relations);
         $this->assertNull(Arr::get($relations, 'posts'));
+    }
+
+    #[Test]
+    public function it_logs_debug_when_method_throws_exception()
+    {
+        Log::spy();
+
+        $finder = new RelationFinder();
+
+        $relations = $finder->getModelRelations(ModelWithThrowingMethod::class);
+
+        $this->assertCount(0, $relations);
+
+        Log::shouldHaveReceived('debug')
+            ->withArgs(function (string $message) {
+                return str_contains($message, 'Could not analyze method')
+                    && str_contains($message, 'throwingMethod')
+                    && str_contains($message, 'Something went wrong');
+            })
+            ->once();
     }
 
 }


### PR DESCRIPTION
## Summary

### What I have done
- Add opt-in debug logging to the `catch (\Throwable $e)` block in `RelationFinder::getRelationshipFromMethodAndModel()`.
- Logging is disabled by default and can be enabled by setting `'debug_relations' => true` in `config/erd-generator.php`.
- Add test to verify debug logging behavior when a method throws an exception.

### Motivation
As reported in Issue #61, users have encountered silent failures inside the catch block of `getRelationshipFromMethodAndModel`, making it difficult to diagnose why relations are not detected. 
This PR surfaces those errors in an opt-in manner, without polluting logs in production environments.

### Changed
- `src/RelationFinder.php`: Wrapped `Log::debug()` with a `config('erd-generator.debug_relations', false)` guard
- `config/erd-generator.php`: Added commented-out `debug_relations` option with description
- `tests/Fixtures/ModelWithThrowingMethod.php`: Test model that throws an exception
- `tests/GetModelRelationsTest.php`: Test verifying the debug log output

## Test Results

<img width="1074" height="160" alt="Screen Shot 2026-05-14 10 02 29" src="https://github.com/user-attachments/assets/83cb6de3-12f7-4cdb-ac79-2568da210773" />